### PR TITLE
Migration from bcdev

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,22 @@
+name: Publish package to the Maven Central Repository
+on:
+  release:
+    types: [created]
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Maven Central Repository
+        uses: actions/setup-java@v3
+        with:
+          java-version: '11'
+          distribution: 'adopt'
+          server-id: ossrh
+          server-username: MAVEN_USERNAME
+          server-password: MAVEN_PASSWORD
+      - name: Publish package
+        run: mvn --batch-mode deploy
+        env:
+          MAVEN_USERNAME: ${{ secrets.OSSRH_USERNAME }}
+          MAVEN_PASSWORD: ${{ secrets.OSSRH_TOKEN }}

--- a/pom.xml
+++ b/pom.xml
@@ -4,9 +4,9 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
-    <groupId>com.bc.zarr</groupId>
+    <groupId>dev.zarr</groupId>
     <artifactId>jzarr</artifactId>
-    <version>0.3.6-SNAPSHOT</version>
+    <version>0.3.6</version>
 
     <properties>
         <!-- needed in test scope to show examples -->
@@ -108,18 +108,14 @@
     </dependencies>
 
     <distributionManagement>
-        <repository>
-            <id>bc-nexus-repo</id>
-            <name>Public Maven Repository for BC</name>
-            <url>http://nexus.senbox.net/nexus/content/repositories/releases/</url>
-            <uniqueVersion>false</uniqueVersion>
-        </repository>
         <snapshotRepository>
-            <id>bc-nexus-repo</id>
-            <name>Public Maven Snapshot Repository for BC</name>
-            <url>http://nexus.senbox.net/nexus/content/repositories/snapshots/</url>
-            <uniqueVersion>false</uniqueVersion>
+            <id>ossrh</id>
+            <url>https://s01.oss.sonatype.org/content/repositories/snapshots</url>
         </snapshotRepository>
+        <repository>
+            <id>ossrh</id>
+            <url>https://s01.oss.sonatype.org/service/local/staging/deploy/maven2/</url>
+        </repository>
     </distributionManagement>
 
     <repositories>


### PR DESCRIPTION
* [x] Change groupId to `dev.zarr`
* [x] Register `dev.zarr` with maven central ([OSSRH-91788](https://issues.sonatype.org/browse/OSSRH-91788))
* [x] Configure the maven central distribution management URLs
* [x] Add a deploy.yml workflow for pushing to maven central
* [x] Bump version to `0.3.6` for release
* [x] Configure secrets on the repository ([more info](https://docs.github.com/en/actions/publishing-packages/publishing-java-packages-with-maven))