### PR TITLE
ZarrArray: add a method to get the `DimensionSeparator`

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -208,14 +208,14 @@
                     </excludes>
                 </configuration>
             </plugin>
-            <!--            <plugin>-->
-            <!--                <groupId>org.apache.maven.plugins</groupId>-->
-            <!--                <artifactId>maven-surefire-plugin</artifactId>-->
-            <!--                <version>3.0.0-M5</version>-->
-            <!--                <configuration>-->
-            <!--                    <argLine>-Djna.library.path=${bloscJnaLibraryPath}</argLine>-->
-            <!--                </configuration>-->
-            <!--            </plugin>-->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-surefire-plugin</artifactId>
+                    <version>3.0.0-M5</version>
+                    <configuration>
+                        <includes>**/*.java</includes>
+                    </configuration>
+             </plugin>
         </plugins>
 
     </build>
@@ -250,6 +250,7 @@
                         <configuration>
                             <argLine>-Djna.library.path=${bloscJnaLibraryPath}</argLine>
                             <systemPropertiesFile>${basedir}/blosc.properties</systemPropertiesFile>
+                            <includes>**/*.java</includes>
                         </configuration>
                     </plugin>
                 </plugins>

--- a/src/main/java/com/bc/zarr/ZarrArray.java
+++ b/src/main/java/com/bc/zarr/ZarrArray.java
@@ -210,6 +210,10 @@ public class ZarrArray {
         return _byteOrder;
     }
 
+    public DimensionSeparator getDimensionSeparator() {
+        return _separator;
+    }
+
     public void write(Number value) throws IOException, InvalidRangeException {
         final int[] shape = getShape();
         final int[] offset = new int[shape.length];

--- a/src/test/java/com/bc/zarr/ZarrArrayTest_dimensionSeparator.java
+++ b/src/test/java/com/bc/zarr/ZarrArrayTest_dimensionSeparator.java
@@ -91,11 +91,8 @@ public class ZarrArrayTest_dimensionSeparator {
     @Test
     public void openOldStyleZarrArrayAndDetectDimensionSeparator() throws IOException, NoSuchFieldException, IllegalAccessException {
         final ZarrArray array = ZarrArray.open(arrayPath);
-        final Object separator = TestUtils.getPrivateFieldObject(array, "_separator");
-        assertThat(separator)
-                .isNotNull()
-                .isInstanceOf(DimensionSeparator.class);
-        DimensionSeparator sep = (DimensionSeparator) separator;
+        DimensionSeparator sep = array.getDimensionSeparator();
+        assertThat(sep).isNotNull();
         assertThat(sep.getSeparatorChar()).isEqualTo("/");
     }
 


### PR DESCRIPTION
See https://github.com/bcdev/jzarr/pull/32

3a4e7ddc46b adds a simple getter to `ZarrArray` to retrieve the `DimensionSeparator`. It also updates the dimension separator test to use the new getter.

When updating the dimension separator test, I noticed that some of the tests were not being run. b4eed70 fixes it so that every test class is run.