### PR TITLE
Reconcile nested/dimension separator changes

### DIFF
--- a/src/main/java/com/bc/zarr/ArrayParams.java
+++ b/src/main/java/com/bc/zarr/ArrayParams.java
@@ -191,7 +191,9 @@ public class ArrayParams {
         if (sep == null) {
             this.separator = DimensionSeparator.DOT;
         }
-        this.separator = sep;
+        else {
+            this.separator = sep;
+        }
         return this;
     }
 

--- a/src/main/java/com/bc/zarr/ZarrHeader.java
+++ b/src/main/java/com/bc/zarr/ZarrHeader.java
@@ -70,7 +70,14 @@ public class ZarrHeader {
         }
         this.fill_value = fill_value;
         this.shape = shape;
-        this.dimension_separator = dimension_separator;
+
+        if (dimension_separator != null) {
+            this.dimension_separator = dimension_separator;
+        }
+        else {
+            // consistent with ArrayParams' handling of null separators
+            this.dimension_separator = ".";
+        }
     }
 
     public int[] getChunks() {

--- a/src/test/java/com/bc/zarr/ZarrUtilsTest.java
+++ b/src/test/java/com/bc/zarr/ZarrUtilsTest.java
@@ -156,6 +156,11 @@ public class ZarrUtilsTest {
         assertEquals("1.2.3.42", ZarrUtils.createChunkFilename(new int[]{1, 2, 3, 42}, "."));
     }
 
+    @Test
+    public void computeChunkFilename2() {
+        assertEquals("1/2/3/42", ZarrUtils.createChunkFilename(new int[]{1, 2, 3, 42}, "/"));
+    }
+
     private String expectedJson(boolean nullCompressor) {
         final StringWriter sw = new StringWriter();
         final PrintWriter pw = new PrintWriter(sw);

--- a/src/test/java/com/bc/zarr/storage/FileSystemStoreTest.java
+++ b/src/test/java/com/bc/zarr/storage/FileSystemStoreTest.java
@@ -67,7 +67,8 @@ public class FileSystemStoreTest {
     public static Collection<Object[]> data() {
         return Arrays.asList(new Object[][] {
             {DimensionSeparator.DOT},
-            {DimensionSeparator.SLASH}
+            {DimensionSeparator.SLASH},
+            {null}
         });
     }
 
@@ -77,7 +78,7 @@ public class FileSystemStoreTest {
 
     @Before
     public void setUp() throws Exception {
-        testDataStr = "testData_" + (separator == DimensionSeparator.SLASH ? "nested" : "flat");
+        testDataStr = String.format("testData_%s", separator);
         rootPathStr = "group.zarr";
 
         final int fileSystemAlternative = 1;
@@ -226,7 +227,7 @@ public class FileSystemStoreTest {
         assertThat(Files.isReadable(fooPath.resolve(FILENAME_DOT_ZARRAY)), is(true));
         assertThat(Files.isReadable(fooPath.resolve(FILENAME_DOT_ZATTRS)), is(true));
         final ZarrHeader header = new ZarrHeader(shape, chunks, DataType.i1.toString(), ByteOrder.LITTLE_ENDIAN,
-                                                 0, null, separator.getSeparatorChar());
+                                                 0, null, separator == null ? null : separator.getSeparatorChar());
         final String expected = strip(ZarrUtils.toJson(header, true));
         assertThat(strip(getZarrayContent(fooPath)), is(equalToIgnoringWhiteSpace(expected)));
         assertThat(strip(getZattrsContent(fooPath)), is("{\"data\":[4.0,5.0,6.0,7.0,8.0]}"));
@@ -281,7 +282,12 @@ public class FileSystemStoreTest {
         // Reopen the array to check that nesting v. flatness is detected.
         final ZarrGroup rootGrp2 = ZarrGroup.create(store, null);
         final ZarrArray fooArray2 = rootGrp.openArray("foo");
-        assertEquals(separator, fooArray2.getDimensionSeparator());
+        if (separator == null) {
+            assertEquals(DimensionSeparator.DOT, fooArray2.getDimensionSeparator());
+        }
+        else {
+            assertEquals(separator, fooArray2.getDimensionSeparator());
+        }
     }
 
     @Test

--- a/src/test/java/com/bc/zarr/storage/FileSystemStoreTest.java
+++ b/src/test/java/com/bc/zarr/storage/FileSystemStoreTest.java
@@ -32,6 +32,8 @@ import com.google.common.jimfs.Jimfs;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
 import ucar.ma2.InvalidRangeException;
 
 import java.io.IOException;
@@ -44,10 +46,12 @@ import static com.bc.zarr.TestUtils.*;
 import static com.bc.zarr.ZarrConstants.*;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.*;
+import static org.junit.Assert.*;
 
 /**
  * Test along https://zarr.readthedocs.io/en/stable/api/storage.html#zarr.storage.DirectoryStore
  */
+@RunWith(Parameterized.class)
 public class FileSystemStoreTest {
 
     private String testDataStr;
@@ -57,9 +61,23 @@ public class FileSystemStoreTest {
     private Path rootPath;
     private Path testDataPath;
 
+    private final DimensionSeparator separator;
+
+    @Parameterized.Parameters
+    public static Collection<Object[]> data() {
+        return Arrays.asList(new Object[][] {
+            {DimensionSeparator.DOT},
+            {DimensionSeparator.SLASH}
+        });
+    }
+
+    public FileSystemStoreTest(DimensionSeparator sep) {
+        this.separator = sep;
+    }
+
     @Before
     public void setUp() throws Exception {
-        testDataStr = "testData";
+        testDataStr = "testData_" + (separator == DimensionSeparator.SLASH ? "nested" : "flat");
         rootPathStr = "group.zarr";
 
         final int fileSystemAlternative = 1;
@@ -198,7 +216,7 @@ public class FileSystemStoreTest {
                 .byteOrder(ByteOrder.LITTLE_ENDIAN)
                 .fillValue(0)
                 .compressor(null)
-                .dimensionSeparator(DimensionSeparator.SLASH);
+                .dimensionSeparator(separator);
         final ZarrArray fooArray = rootGrp.createArray("foo", parameters, attributes);
 
         //verification
@@ -208,7 +226,7 @@ public class FileSystemStoreTest {
         assertThat(Files.isReadable(fooPath.resolve(FILENAME_DOT_ZARRAY)), is(true));
         assertThat(Files.isReadable(fooPath.resolve(FILENAME_DOT_ZATTRS)), is(true));
         final ZarrHeader header = new ZarrHeader(shape, chunks, DataType.i1.toString(), ByteOrder.LITTLE_ENDIAN,
-                                                 0, null, DimensionSeparator.SLASH.getSeparatorChar());
+                                                 0, null, separator.getSeparatorChar());
         final String expected = strip(ZarrUtils.toJson(header, true));
         assertThat(strip(getZarrayContent(fooPath)), is(equalToIgnoringWhiteSpace(expected)));
         assertThat(strip(getZattrsContent(fooPath)), is("{\"data\":[4.0,5.0,6.0,7.0,8.0]}"));
@@ -225,7 +243,7 @@ public class FileSystemStoreTest {
 
         final ArrayParams parameters = new ArrayParams()
                 .dataType(DataType.i1).shape(shape).chunks(chunks)
-                .fillValue(0).compressor(null);
+                .fillValue(0).compressor(null).dimensionSeparator(separator);
 
         //execution
         final ZarrGroup rootGrp = ZarrGroup.create(store, null);
@@ -235,10 +253,22 @@ public class FileSystemStoreTest {
         //verification
         final Path fooPath = rootPath.resolve("foo");
         assertThat(Files.isDirectory(fooPath), is(true));
-        assertThat(Files.list(fooPath).filter(
-                path -> !path.getFileName().toString().startsWith(".")
-        ).count(), is(4L));
-        final String[] chunkFileNames = {"0.0", "0.1", "1.0", "1.1"};
+
+        String[] chunkFileNames;
+        if (separator == DimensionSeparator.SLASH) {
+            List<Path> names = Files.list(fooPath).collect(Collectors.toList());
+            assertThat(names.toString(),
+                    Files.list(fooPath).filter(
+                    path -> !path.getFileName().toString().startsWith(".")
+            ).count(), is(2L));
+            chunkFileNames = new String[]{"0/0", "0/1", "1/0", "1/1"};
+        } else {
+            assertThat(Files.list(fooPath).filter(
+                    path -> !path.getFileName().toString().startsWith(".")
+            ).count(), is(4L));
+            chunkFileNames = new String[]{"0.0", "0.1", "1.0", "1.1"};
+        }
+
         final byte[] expectedBytes = new byte[25];
         Arrays.fill(expectedBytes, (byte) 42);
         for (String name : chunkFileNames) {
@@ -247,6 +277,11 @@ public class FileSystemStoreTest {
             assertThat(Files.size(chunkPath), is(5L * 5));
             assertThat(Files.readAllBytes(chunkPath), is(expectedBytes));
         }
+
+        // Reopen the array to check that nesting v. flatness is detected.
+        final ZarrGroup rootGrp2 = ZarrGroup.create(store, null);
+        final ZarrArray fooArray2 = rootGrp.openArray("foo");
+        assertEquals(separator, fooArray2.getDimensionSeparator());
     }
 
     @Test


### PR DESCRIPTION
I believe this covers the changes referenced in https://github.com/glencoesoftware/bioformats2raw/pull/203#issuecomment-1557262295, which were picked from https://github.com/glencoesoftware/jzarr/pull/1. This is a prerequisite for migrating https://github.com/glencoesoftware/jzarr/pull/4#issuecomment-1558076465.

The original commits referenced (from @joshmoore) used a `Boolean nested` to determine the dimension separator. The original commits significantly conflict with `main`, as the API here now uses a `DimensionSeparator` enum directly. I did not try to cherry-pick and resolve conflicts, but added relevant changes and referenced the original commits in the new commit messages. Hopefully that's reasonably clear.

Mostly this is fixing `ArrayParams` and `ZarrHeader` to really default to `DimensionSeparator.DOT` if a null was supplied, and expanding the relevant tests to cover all three possible `DimensionSeparator` values.