### PR TITLE
Allow configuration of default properties of blosc compressor

### DIFF
--- a/src/main/java/com/bc/zarr/CompressorFactory.java
+++ b/src/main/java/com/bc/zarr/CompressorFactory.java
@@ -298,7 +298,6 @@ public class CompressorFactory {
             } else {
                 this.nthreads = ((Number) nthreadsObj).intValue();
             }
-            System.out.println(nthreads);
         }
 
         @Override

--- a/src/main/java/com/bc/zarr/CompressorFactory.java
+++ b/src/main/java/com/bc/zarr/CompressorFactory.java
@@ -208,7 +208,7 @@ public class CompressorFactory {
         }
     }
 
-    static class BloscCompressor extends Compressor {
+    public static class BloscCompressor extends Compressor {
 
         final static int AUTOSHUFFLE = -1;
         final static int NOSHUFFLE = 0;
@@ -228,14 +228,13 @@ public class CompressorFactory {
         public final static int[] supportedShuffle = new int[]{/*AUTOSHUFFLE, */NOSHUFFLE, BYTESHUFFLE, BITSHUFFLE};
         public final static String[] supportedCnames = new String[]{"zstd", "blosclz", defaultCname, "lz4hc", "zlib"/*, "snappy"*/};
 
-        public final static Map<String, Object> defaultProperties = Collections
-                .unmodifiableMap(new HashMap<String, Object>() {{
+        public final static Map<String, Object> defaultProperties = new HashMap<String, Object>() {{
                     put(keyCname, defaultCname);
                     put(keyClevel, defaultCLevel);
                     put(keyShuffle, defaultShuffle);
                     put(keyBlocksize, defaultBlocksize);
                     put(keyNumThreads, defaultNumThreads);
-                }});
+                }};
 
         private final int clevel;
         private final int blocksize;
@@ -290,14 +289,16 @@ public class CompressorFactory {
                 this.blocksize = ((Number) blocksizeObj).intValue();
             }
 
-            final Object nthreadsObj = map.get(keyNumThreads);
+            Object nthreadsObj = map.get(keyNumThreads);
             if (nthreadsObj == null) {
-                this.nthreads = defaultNumThreads;
-            } else if (nthreadsObj instanceof String) {
+                nthreadsObj = defaultProperties.get(keyNumThreads);
+            }
+            if (nthreadsObj instanceof String) {
                 this.nthreads = Integer.parseInt((String) nthreadsObj);
             } else {
                 this.nthreads = ((Number) nthreadsObj).intValue();
             }
+            System.out.println(nthreads);
         }
 
         @Override


### PR DESCRIPTION

*Originally opened as https://github.com/bcdev/jzarr/pull/42*

----

The goal of this PR is to allow the user to set the number of threads used for blosc decompression on the auto-created Compressor objects during read operations.

This is done via CompressorFactory.BloscCompressor.defaultProperties.put("nthreads", 8);

This was the least invasive/modifying approach I could find (in conjunction with PR https://github.com/bcdev/jzarr/pull/41 for user defined compressor objects). However, it does expose the actual BloscCompressor class and the implementation of the map. I'd be happy to implement something more extensive keeps the class implementation private if the maintainers prefer.

I also only updated the nthreads property to pull from the defaultProperties map rather than the default constants. If this approach is acceptable, I can change the other properties to have the same behavior.