### PR TITLE
Allow compressors to be registered with CompressorFactory

### DIFF
--- a/src/test/java/com/bc/zarr/CompressorFactoryTest.java
+++ b/src/test/java/com/bc/zarr/CompressorFactoryTest.java
@@ -28,6 +28,9 @@ package com.bc.zarr;
 
 import org.junit.Test;
 
+import java.io.InputStream;
+import java.io.IOException;
+import java.io.OutputStream;
 import java.util.Map;
 
 import static org.junit.Assert.assertEquals;
@@ -117,6 +120,34 @@ public class CompressorFactoryTest {
             fail("IllegalArgumentException expected");
         } catch (IllegalArgumentException expected) {
             assertEquals("Compressor id:'kkkkkkk' not supported.", expected.getMessage());
+        }
+    }
+
+    @Test
+    public void registerNewCompressor() {
+        final String id = "test";
+        CompressorFactory.registerCompressor(id, TestCompressor.class);
+        final Compressor compressor = CompressorFactory.create(id, TestUtils.createMap("level", 1));
+        assertNotNull(compressor);
+        assertEquals(id, compressor.getId());
+    }
+
+    static class TestCompressor extends Compressor {
+        public TestCompressor(Map<String, Object> properties) {
+        }
+
+        public String getId() {
+          return "test";
+        }
+
+        public String toString() {
+          return getId();
+        }
+
+        public void compress(InputStream is, OutputStream os) throws IOException {
+        }
+
+        public void uncompress(InputStream is, OutputStream os) throws IOException {
         }
     }
 }


### PR DESCRIPTION
Migrated from https://github.com/glencoesoftware/jzarr/pull/4, as suggested by @joshmoore.

This makes some minimal changes to allow compressors other than zlib and blosc to be registered, and adds a corresponding test case. No new compression types are supported here, this is just one way to make the compression types more extensible.

I wouldn't necessarily expect this to be merged as-is, and would be happy to hear other thoughts on how to implement this feature.