### PR TITLE
Blosc compressor: numThreads serialization fix

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>dev.zarr</groupId>
     <artifactId>jzarr</artifactId>
-    <version>0.4.0</version>
+    <version>0.4.1-SNAPSHOT</version>
 
     <name>JZarr</name>
 

--- a/src/main/java/com/bc/zarr/CompressorFactory.java
+++ b/src/main/java/com/bc/zarr/CompressorFactory.java
@@ -26,6 +26,7 @@
 
 package com.bc.zarr;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.sun.jna.ptr.NativeLongByReference;
 import org.blosc.BufferSizes;
 import org.blosc.IBloscDll;
@@ -319,6 +320,11 @@ public class CompressorFactory {
 
         public String getCname() {
             return cname;
+        }
+
+        @JsonIgnore
+        public int getNumThreads() {
+            return nthreads;
         }
 
         @Override

--- a/src/main/java/com/bc/zarr/CompressorFactory.java
+++ b/src/main/java/com/bc/zarr/CompressorFactory.java
@@ -321,10 +321,6 @@ public class CompressorFactory {
             return cname;
         }
 
-        public int getNumThreads() {
-            return nthreads;
-        }
-
         @Override
         public String toString() {
             return "compressor=" + getId()

--- a/src/test/java/com/bc/zarr/CompressorFactoryTest.java
+++ b/src/test/java/com/bc/zarr/CompressorFactoryTest.java
@@ -119,4 +119,96 @@ public class CompressorFactoryTest {
             assertEquals("Compressor id:'kkkkkkk' not supported.", expected.getMessage());
         }
     }
+
+    @Test
+    public void createBloscValidCnames() {
+        String[] cnames = { "zstd", "blosclz", "lz4", "lz4hc", "zlib" };
+        for (int i = 0; i < cnames.length; i += 1) {
+            final Compressor compressor = CompressorFactory.create("blosc", "cname", cnames[i]);
+            assertNotNull(compressor);
+            assertEquals("blosc", compressor.getId());
+            assertEquals(
+                "compressor=blosc/cname=" + cnames[i] +
+                "/clevel=5/blocksize=0/shuffle=1", compressor.toString());
+        }
+    }
+
+    @Test
+    public void createBloscInvalidCname() {
+        try {
+            CompressorFactory.create("blosc", "cname", "unsupported");
+            fail("IllegalArgumentException expected");
+        } catch (IllegalArgumentException expected) {
+            assertEquals("blosc: compressor not supported: 'unsupported'; expected one of [zstd, blosclz, lz4, lz4hc, zlib]", expected.getMessage());
+        }
+   }
+
+   @Test
+   public void createBloscValidClevel() {
+       final Compressor compressor = CompressorFactory.create("blosc", "clevel", 1);
+       assertNotNull(compressor);
+       assertEquals("blosc", compressor.getId());
+       assertEquals(
+           "compressor=blosc/cname=lz4" +
+           "/clevel=1/blocksize=0/shuffle=1", compressor.toString());
+   }
+
+   @Test
+   public void createBloscInvalidClevel() {
+       try {
+           CompressorFactory.create("blosc", "clevel", -1);
+           fail("IllegalArgumentException expected");
+       } catch (IllegalArgumentException expected) {
+           assertEquals("blosc: clevel parameter must be between 0 and 9 but was: -1", expected.getMessage());
+       }
+
+       try {
+           CompressorFactory.create("blosc", "clevel", 10);
+           fail("IllegalArgumentException expected");
+       } catch (IllegalArgumentException expected) {
+           assertEquals(
+               "blosc: clevel parameter must be between 0 and 9 but was: 10",
+               expected.getMessage());
+       }
+   }
+
+   @Test
+   public void createBloscValidShuffles() {
+       int[] shuffles = { 0, 1, 2 };
+       for (int i = 0; i < shuffles.length; i += 1) {
+           final Compressor compressor = CompressorFactory.create("blosc", "shuffle", shuffles[i]);
+           assertNotNull(compressor);
+           assertEquals("blosc", compressor.getId());
+           assertEquals(
+               "compressor=blosc/cname=lz4" +
+               "/clevel=5/blocksize=0/shuffle=" +
+               shuffles[i], compressor.toString());
+       }
+   }
+
+   @Test
+   public void createBloscInvalidShuffle() {
+       try {
+           CompressorFactory.create("blosc", "shuffle", -1);
+           fail("IllegalArgumentException expected");
+       } catch (IllegalArgumentException expected) {
+           assertEquals(
+               "blosc: shuffle type not supported: '-1'; expected one of [0 (NOSHUFFLE), 1 (BYTESHUFFLE), 2 (BITSHUFFLE)]",
+               expected.getMessage());
+       }
+  }
+
+  @Test
+  public void createBloscValidBlockSizes() {
+      int[] blockSizes = { 0, 1, 20 };
+      for (int i = 0; i < blockSizes.length; i += 1) {
+          final Compressor compressor = CompressorFactory.create("blosc", "blocksize", blockSizes[i]);
+          assertNotNull(compressor);
+          assertEquals("blosc", compressor.getId());
+          assertEquals(
+              "compressor=blosc/cname=lz4" +
+              "/clevel=5/blocksize=" + blockSizes[i] +
+              "/shuffle=1", compressor.toString());
+      }
+  }
 }

--- a/src/test/java/com/bc/zarr/ZarrArrayDataReaderWriterTest_2D_writeAndReadData.java
+++ b/src/test/java/com/bc/zarr/ZarrArrayDataReaderWriterTest_2D_writeAndReadData.java
@@ -57,11 +57,11 @@ public class ZarrArrayDataReaderWriterTest_2D_writeAndReadData {
     }
 
     @Test
-    public void getCompressor() throws IOException {
+    public void getNullCompressor() throws IOException {
         final int[] shape = {1, 1};
         final int[] chunkShape = {1, 1};
         final DataType dataType = DataType.i1; // Byte
-        final Compressor compressor = CompressorFactory.nullCompressor;
+        final Compressor compressor = CompressorFactory.create("null");
         final ArrayParams parameters = new ArrayParams()
                 .shape(shape).chunks(chunkShape)
                 .dataType(dataType)
@@ -69,6 +69,36 @@ public class ZarrArrayDataReaderWriterTest_2D_writeAndReadData {
         final ZarrArray array = ZarrArray.create(
                 new ZarrPath(arrayName), store, parameters, null);
         array.getCompressor();
+        assertEquals(compressor, array.getCompressor());
+    }
+
+    @Test
+    public void getBloscCompressor() throws IOException {
+        final int[] shape = {1, 1};
+        final int[] chunkShape = {1, 1};
+        final DataType dataType = DataType.i1; // Byte
+        final Compressor compressor = CompressorFactory.create("blosc");
+        final ArrayParams parameters = new ArrayParams()
+                .shape(shape).chunks(chunkShape)
+                .dataType(dataType)
+                .compressor(compressor);
+        final ZarrArray array = ZarrArray.create(
+                new ZarrPath(arrayName), store, parameters, null);
+        assertEquals(compressor, array.getCompressor());
+    }
+
+    @Test
+    public void getZlibCompressor() throws IOException {
+        final int[] shape = {1, 1};
+        final int[] chunkShape = {1, 1};
+        final DataType dataType = DataType.i1; // Byte
+        final Compressor compressor = CompressorFactory.create("zlib");
+        final ArrayParams parameters = new ArrayParams()
+                .shape(shape).chunks(chunkShape)
+                .dataType(dataType)
+                .compressor(compressor);
+        final ZarrArray array = ZarrArray.create(
+                new ZarrPath(arrayName), store, parameters, null);
         assertEquals(compressor, array.getCompressor());
     }
 

--- a/src/test/java/com/bc/zarr/ZarrUtilsTestCompression.java
+++ b/src/test/java/com/bc/zarr/ZarrUtilsTestCompression.java
@@ -1,0 +1,151 @@
+/*
+ *
+ * MIT License
+ *
+ * Copyright (c) 2020. Brockmann Consult GmbH (info@brockmann-consult.de)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ */
+
+package com.bc.zarr;
+
+import static org.hamcrest.Matchers.*;
+import static org.hamcrest.MatcherAssert.*;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertArrayEquals;
+
+import org.junit.*;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.io.StringReader;
+import java.io.StringWriter;
+import java.nio.ByteOrder;
+import java.util.Arrays;
+import java.util.Collection;
+
+@RunWith(Parameterized.class)
+public class ZarrUtilsTestCompression {
+
+    private ZarrHeader _zarrHeader;
+    private final String compression;
+
+    @Parameterized.Parameters
+    public static Collection<String[]> getCompressions() {
+        return Arrays.asList(new String[][] {
+            {"blosc"},
+            {"zlib"},
+            {"null"}
+        });
+    }
+
+    public ZarrUtilsTestCompression(String compression) {
+        this.compression = compression;
+    }
+
+    @Before
+    public void setUp() {
+        final int[] chunks = {5, 6};
+        final Compressor compressor = CompressorFactory.create(compression);
+        final String dtype = "i4";
+        final int[] shape = {10, 15};
+        _zarrHeader = new ZarrHeader(shape, chunks, dtype, ByteOrder.BIG_ENDIAN, 3.6d, compressor, DimensionSeparator.DOT.getSeparatorChar());
+    }
+
+    @Test
+    public void toJson() throws IOException {
+        final StringWriter writer = new StringWriter();
+
+        ZarrUtils.toJson(_zarrHeader, writer);
+        assertThat(strip(writer.toString()), is(equalToIgnoringWhiteSpace(expectedJson(compression))));
+    }
+
+
+    @Test
+    public void fromJson() throws IOException {
+        //execution
+        final ZarrHeader zarrHeader = ZarrUtils.fromJson(new StringReader(expectedJson(compression)), ZarrHeader.class);
+
+        //verification
+        assertNotNull(zarrHeader);
+        assertThat(zarrHeader.getChunks(), is(equalTo(_zarrHeader.getChunks())));
+        assertThat(zarrHeader.getDtype(), is(equalTo(_zarrHeader.getDtype())));
+        if (compression == "null") {
+            assertNull(zarrHeader.getCompressor());
+        } else {
+            assertNotNull(zarrHeader.getCompressor());
+            assertThat(zarrHeader.getCompressor().toString(), is(equalTo(_zarrHeader.getCompressor().toString())));
+        }
+        assertThat(zarrHeader.getFill_value().doubleValue(), is(equalTo(_zarrHeader.getFill_value().doubleValue())));
+        assertThat(zarrHeader.getShape(), is(equalTo(_zarrHeader.getShape())));
+    }
+
+
+    private String expectedJson(String compression) {
+        final StringWriter sw = new StringWriter();
+        final PrintWriter pw = new PrintWriter(sw);
+        pw.println("{");
+        pw.println("    \"chunks\": [");
+        pw.println("        5,");
+        pw.println("        6");
+        pw.println("    ],");
+        if (compression == "null") {
+            pw.println("    \"compressor\": null,");
+        } else if (compression == "zlib") {
+            pw.println("    \"compressor\": {");
+            pw.println("        \"level\": 1,");
+            pw.println("        \"id\": \"zlib\"");
+            pw.println("    },");
+        } else if (compression == "blosc") {
+            pw.println("    \"compressor\": {");
+            pw.println("        \"clevel\": 5,");
+            pw.println("        \"blocksize\": 0,");
+            pw.println("        \"shuffle\": 1,");
+            pw.println("        \"cname\": \"lz4\",");
+            pw.println("        \"id\": \"blosc\"");
+            pw.println("    },");
+        }
+        pw.println("    \"dtype\": \">i4\",");
+        pw.println("    \"fill_value\": 3.6,");
+        pw.println("    \"filters\": null,");
+        pw.println("    \"order\": \"C\",");
+        pw.println("    \"shape\": [");
+        pw.println("        10,");
+        pw.println("        15");
+        pw.println("    ],");
+        pw.println("    \"dimension_separator\": \".\",");
+        pw.println("    \"zarr_format\": 2");
+        pw.println("}");
+
+        return strip(sw.toString());
+    }
+
+    private String strip(String s) {
+        s = s.replace("\r", "").replace("\n", "");
+        s = s.replace(" ", "");
+//        while (s.contains("  ")) s = s.replace("  ", " ");
+        return s;
+    }
+
+}


### PR DESCRIPTION
Fixes #14  

As described in the accompanying issues, changes in 0.4.0 are causing the addition of the key `numThreads` to the compression map under `.zarray` when using blosc.

This serialization change causes compatibility issues with the expectations of `numcodecs` - see https://numcodecs.readthedocs.io/en/stable/blosc.html#numcodecs.blosc.Blosc. A formal specification of the blosc codec and its supported configuration values is available in the Zarr v3 specification https://zarr-specs.readthedocs.io/en/latest/v3/codecs/blosc/v1.0.html#blosc-codec-version-1-0. Although it's not 100% clear whether this dictionary should be considered as extensible, the number of threads used for compression is a writing concern which is fully independent of the reading/decompression mechanism (which might very well used different number of threads) so it seems incorrect to serialize it in the first place.

Tracking down the source of the issue with @melissalinkert, it was found to be introduced in #4 more specifically via the `getNumThreads` getter method which seems to be serialized under `.zarray` through the `jackson-databind` `ObjectMapper` API. 43cf7f3b4e14627b272faf25bb00b457267a1b4c proposes to remove the getter which suffices to fix the issue while retaining the initial feature.

Opening for initial feedback, it is pretty clear that both the feature and the blosc serialization logic were missing some minimal unit tests which would be great to introduce as part of this PR so that we don't create inadvertent regressions in the future.
