### PR TITLE
Unidata repository

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -153,17 +153,9 @@
 
     <repositories>
         <repository>
-            <id>snap-repo-public</id>
-            <name>Public Maven Repository for SNAP</name>
-            <url>https://snap-build-server.tilaa.cloud/nexus/repository/snap-maven-public/</url>
-            <releases>
-                <enabled>true</enabled>
-                <checksumPolicy>warn</checksumPolicy>
-            </releases>
-            <snapshots>
-                <enabled>true</enabled>
-                <checksumPolicy>warn</checksumPolicy>
-            </snapshots>
+            <id>unidata.releases</id>
+            <url>https://artifacts.unidata.ucar.edu/content/repositories/unidata-releases</url>
+            <snapshots><enabled>false</enabled></snapshots>
         </repository>
     </repositories>
 

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>dev.zarr</groupId>
     <artifactId>jzarr</artifactId>
-    <version>0.4.2-SNAPSHOT</version>
+    <version>0.4.2</version>
 
     <name>JZarr</name>
 


### PR DESCRIPTION
The tilaa.cloud based server introduced in
https://github.com/bcdev/jzarr/commit/020f964fa729779f8cd07a6bd3b11e1fa2b2a0b1 no longer has a valid certificate leading to build errors. This PR migrates to the official Unidata repository as in https://github.com/ome/ZarrReader/pull/66