### PR TITLE
Increase ZarrPath visibility to public

### DIFF
--- a/src/main/java/com/bc/zarr/ZarrPath.java
+++ b/src/main/java/com/bc/zarr/ZarrPath.java
@@ -26,7 +26,7 @@
 
 package com.bc.zarr;
 
-class ZarrPath {
+public class ZarrPath {
     final String storeKey;
 
     ZarrPath(String storeKey) {


### PR DESCRIPTION
It's not possible to use several quite useful public static methods from `ZarrUtils` without access to `ZarrPath`. The most useful is `ZarrUtils.readAttributes()` which avoids the need to know whether attributes are on a group or an array.