### PR TITLE
Extensible CompressorFactory registry.

### DIFF
--- a/src/main/java/com/bc/zarr/Compressor.java
+++ b/src/main/java/com/bc/zarr/Compressor.java
@@ -40,7 +40,7 @@ public abstract class Compressor {
 
     public abstract void uncompress(InputStream is, OutputStream os) throws IOException;
 
-    void passThrough(InputStream is, OutputStream os) throws IOException {
+    protected void passThrough(InputStream is, OutputStream os) throws IOException {
         final byte[] bytes = new byte[4096];
         int read = is.read(bytes);
         while (read >= 0) {

--- a/src/main/java/com/bc/zarr/CompressorFactory.java
+++ b/src/main/java/com/bc/zarr/CompressorFactory.java
@@ -40,7 +40,6 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.nio.ByteBuffer;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.zip.Deflater;
@@ -51,6 +50,17 @@ import java.util.zip.InflaterInputStream;
 public class CompressorFactory {
 
     public final static Compressor nullCompressor = new NullCompressor();
+
+    private static final Map<String, Class<? extends Compressor>> registeredCompressors = defaultCompressors();
+
+    private static Map<String, Class<? extends Compressor>> defaultCompressors() {
+        Map<String, Class<? extends Compressor>> compressors = new HashMap<>();
+        compressors.put("null", NullCompressor.class);
+        compressors.put("zlib", ZlibCompressor.class);
+        compressors.put("blosc", BloscCompressor.class);
+
+        return compressors;
+    }
 
     /**
      * @return the properties of the default compressor as a key/value map.
@@ -67,6 +77,26 @@ public class CompressorFactory {
         map.putAll(BloscCompressor.defaultProperties);
 
         return map;
+    }
+
+    /**
+     * Add or replace a Compressor class for a given id.
+     *
+     * @param id         the type of the compression algorithm
+     * @param compressor the class to instantiate
+     */
+    public static void registerCompressor(String id, Class<? extends Compressor> compressor) {
+        if (id != null) {
+            registeredCompressors.put(id, compressor);
+        }
+    }
+
+    public static String[] listRegisteredCompressorIds() {
+        return registeredCompressors.keySet().toArray(new String[0]);
+    }
+
+    public static Map<String, Class<? extends Compressor>> listRegisteredCompressors() {
+        return new HashMap<>(registeredCompressors);
     }
 
     /**
@@ -92,7 +122,7 @@ public class CompressorFactory {
      * Creates a new {@link Compressor} instance according to the id and the given properties.
      *
      * @param id           the type of the compression algorithm
-     * @param keyValuePair an even count of key value pairs defining the compressor specific properties
+     * @param keyValuePair an even count of key value pairs defining the compressor-specific properties
      * @return a new Compressor instance according to the id and the properties
      * @throws IllegalArgumentException If it is not able to create a Compressor.
      */
@@ -107,20 +137,27 @@ public class CompressorFactory {
      * Creates a new {@link Compressor} instance according to the id and the given properties.
      *
      * @param id         the type of the compression algorithm
-     * @param properties a Map containing the compressor specific properties
+     * @param properties a Map containing the compressor-specific properties
      * @return a new Compressor instance according to the id and the properties
      * @throws IllegalArgumentException If it is not able to create a Compressor.
      */
     public static Compressor create(String id, Map<String, Object> properties) {
-        if ("null".equals(id)) {
-            return nullCompressor;
+        try {
+            if (registeredCompressors.containsKey(id)) {
+                Class<? extends Compressor> c = registeredCompressors.get(id);
+                if (c.equals(NullCompressor.class)) {
+                    return nullCompressor;
+                }
+                return c.getDeclaredConstructor(Map.class).newInstance(properties);
+            }
+        } catch (ReflectiveOperationException e) {
+            if (e.getCause() instanceof IllegalArgumentException) {
+                throw (IllegalArgumentException) e.getCause();
+            }
+
+            throw new IllegalArgumentException("Could not create compressor with id:'" + id + "'", e);
         }
-        if ("zlib".equals(id)) {
-            return new ZlibCompressor(properties);
-        }
-        if ("blosc".equals(id)) {
-            return new BloscCompressor(properties);
-        }
+
         throw new IllegalArgumentException("Compressor id:'" + id + "' not supported.");
     }
 
@@ -160,7 +197,7 @@ public class CompressorFactory {
     private static class ZlibCompressor extends Compressor {
         private final int level;
 
-        private ZlibCompressor(Map<String, Object> map) {
+        protected ZlibCompressor(Map<String, Object> map) {
             final Object levelObj = map.get("level");
             if (levelObj == null) {
                 this.level = 1; //default value
@@ -230,12 +267,12 @@ public class CompressorFactory {
         public final static String[] supportedCnames = new String[]{"zstd", "blosclz", defaultCname, "lz4hc", "zlib"/*, "snappy"*/};
 
         public final static Map<String, Object> defaultProperties = new HashMap<String, Object>() {{
-                    put(keyCname, defaultCname);
-                    put(keyClevel, defaultCLevel);
-                    put(keyShuffle, defaultShuffle);
-                    put(keyBlocksize, defaultBlocksize);
-                    put(keyNumThreads, defaultNumThreads);
-                }};
+            put(keyCname, defaultCname);
+            put(keyClevel, defaultCLevel);
+            put(keyShuffle, defaultShuffle);
+            put(keyBlocksize, defaultBlocksize);
+            put(keyNumThreads, defaultNumThreads);
+        }};
 
         private final int clevel;
         private final int blocksize;
@@ -243,7 +280,7 @@ public class CompressorFactory {
         private final String cname;
         private final int nthreads;
 
-        private BloscCompressor(Map<String, Object> map) {
+        protected BloscCompressor(Map<String, Object> map) {
             final Object cnameObj = map.get(keyCname);
             if (cnameObj == null) {
                 cname = defaultCname;
@@ -330,8 +367,8 @@ public class CompressorFactory {
         @Override
         public String toString() {
             return "compressor=" + getId()
-                   + "/cname=" + cname + "/clevel=" + clevel
-                   + "/blocksize=" + blocksize + "/shuffle=" + shuffle;
+                    + "/cname=" + cname + "/clevel=" + clevel
+                    + "/blocksize=" + blocksize + "/shuffle=" + shuffle;
         }
 
         @Override
@@ -364,16 +401,15 @@ public class CompressorFactory {
             os.write(outBuffer.array());
         }
 
-        private BufferSizes cbufferSizes(ByteBuffer cbuffer) {
+        protected BufferSizes cbufferSizes(ByteBuffer cbuffer) {
             NativeLongByReference nbytes = new NativeLongByReference();
             NativeLongByReference cbytes = new NativeLongByReference();
             NativeLongByReference blocksize = new NativeLongByReference();
             IBloscDll.blosc_cbuffer_sizes(cbuffer, nbytes, cbytes, blocksize);
             BufferSizes bs = new BufferSizes(nbytes.getValue().longValue(),
-                                             cbytes.getValue().longValue(),
-                                             blocksize.getValue().longValue());
+                    cbytes.getValue().longValue(),
+                    blocksize.getValue().longValue());
             return bs;
         }
     }
 }
-

--- a/src/test/java/com/bc/zarr/BloscCompressorTest.java
+++ b/src/test/java/com/bc/zarr/BloscCompressorTest.java
@@ -54,10 +54,10 @@ public class BloscCompressorTest {
     public static void beforeClass() {
 
         final String bloscJnaLibraryPath = System.getProperty("bloscJnaLibraryPath");
-        System.err.println(bloscJnaLibraryPath);
         final boolean bloscPathDefined = bloscJnaLibraryPath != null;
         final boolean bloscAvailable = isBloscAvailable();
         if (bloscPathDefined && !bloscAvailable) {
+            System.err.println(bloscJnaLibraryPath);
             Assert.fail("Property for blosc has been configured, but blosc is not available.");
         } else {
             Assume.assumeTrue("Blosc library path is not configured. Blosc specifc tests are not executed.", bloscAvailable); // test is skipped if blosc is not available

--- a/src/test/java/com/bc/zarr/CompressorFactoryTest.java
+++ b/src/test/java/com/bc/zarr/CompressorFactoryTest.java
@@ -122,14 +122,14 @@ public class CompressorFactoryTest {
 
     @Test
     public void createBloscValidCnames() {
-        String[] cnames = { "zstd", "blosclz", "lz4", "lz4hc", "zlib" };
+        String[] cnames = {"zstd", "blosclz", "lz4", "lz4hc", "zlib"};
         for (int i = 0; i < cnames.length; i += 1) {
             final Compressor compressor = CompressorFactory.create("blosc", "cname", cnames[i]);
             assertNotNull(compressor);
             assertEquals("blosc", compressor.getId());
             assertEquals(
-                "compressor=blosc/cname=" + cnames[i] +
-                "/clevel=5/blocksize=0/shuffle=1", compressor.toString());
+                    "compressor=blosc/cname=" + cnames[i] +
+                            "/clevel=5/blocksize=0/shuffle=1", compressor.toString());
         }
     }
 
@@ -141,74 +141,93 @@ public class CompressorFactoryTest {
         } catch (IllegalArgumentException expected) {
             assertEquals("blosc: compressor not supported: 'unsupported'; expected one of [zstd, blosclz, lz4, lz4hc, zlib]", expected.getMessage());
         }
-   }
+    }
 
-   @Test
-   public void createBloscValidClevel() {
-       final Compressor compressor = CompressorFactory.create("blosc", "clevel", 1);
-       assertNotNull(compressor);
-       assertEquals("blosc", compressor.getId());
-       assertEquals(
-           "compressor=blosc/cname=lz4" +
-           "/clevel=1/blocksize=0/shuffle=1", compressor.toString());
-   }
+    @Test
+    public void createBloscValidClevel() {
+        final Compressor compressor = CompressorFactory.create("blosc", "clevel", 1);
+        assertNotNull(compressor);
+        assertEquals("blosc", compressor.getId());
+        assertEquals(
+                "compressor=blosc/cname=lz4" +
+                        "/clevel=1/blocksize=0/shuffle=1", compressor.toString());
+    }
 
-   @Test
-   public void createBloscInvalidClevel() {
-       try {
-           CompressorFactory.create("blosc", "clevel", -1);
-           fail("IllegalArgumentException expected");
-       } catch (IllegalArgumentException expected) {
-           assertEquals("blosc: clevel parameter must be between 0 and 9 but was: -1", expected.getMessage());
-       }
+    @Test
+    public void createBloscInvalidClevel() {
+        try {
+            CompressorFactory.create("blosc", "clevel", -1);
+            fail("IllegalArgumentException expected");
+        } catch (IllegalArgumentException expected) {
+            assertEquals("blosc: clevel parameter must be between 0 and 9 but was: -1", expected.getMessage());
+        }
 
-       try {
-           CompressorFactory.create("blosc", "clevel", 10);
-           fail("IllegalArgumentException expected");
-       } catch (IllegalArgumentException expected) {
-           assertEquals(
-               "blosc: clevel parameter must be between 0 and 9 but was: 10",
-               expected.getMessage());
-       }
-   }
+        try {
+            CompressorFactory.create("blosc", "clevel", 10);
+            fail("IllegalArgumentException expected");
+        } catch (IllegalArgumentException expected) {
+            assertEquals(
+                    "blosc: clevel parameter must be between 0 and 9 but was: 10",
+                    expected.getMessage());
+        }
+    }
 
-   @Test
-   public void createBloscValidShuffles() {
-       int[] shuffles = { 0, 1, 2 };
-       for (int i = 0; i < shuffles.length; i += 1) {
-           final Compressor compressor = CompressorFactory.create("blosc", "shuffle", shuffles[i]);
-           assertNotNull(compressor);
-           assertEquals("blosc", compressor.getId());
-           assertEquals(
-               "compressor=blosc/cname=lz4" +
-               "/clevel=5/blocksize=0/shuffle=" +
-               shuffles[i], compressor.toString());
-       }
-   }
+    @Test
+    public void createBloscValidShuffles() {
+        int[] shuffles = {0, 1, 2};
+        for (int i = 0; i < shuffles.length; i += 1) {
+            final Compressor compressor = CompressorFactory.create("blosc", "shuffle", shuffles[i]);
+            assertNotNull(compressor);
+            assertEquals("blosc", compressor.getId());
+            assertEquals(
+                    "compressor=blosc/cname=lz4" +
+                            "/clevel=5/blocksize=0/shuffle=" +
+                            shuffles[i], compressor.toString());
+        }
+    }
 
-   @Test
-   public void createBloscInvalidShuffle() {
-       try {
-           CompressorFactory.create("blosc", "shuffle", -1);
-           fail("IllegalArgumentException expected");
-       } catch (IllegalArgumentException expected) {
-           assertEquals(
-               "blosc: shuffle type not supported: '-1'; expected one of [0 (NOSHUFFLE), 1 (BYTESHUFFLE), 2 (BITSHUFFLE)]",
-               expected.getMessage());
-       }
-  }
+    @Test
+    public void createBloscInvalidShuffle() {
+        try {
+            CompressorFactory.create("blosc", "shuffle", -1);
+            fail("IllegalArgumentException expected");
+        } catch (IllegalArgumentException expected) {
+            assertEquals(
+                    "blosc: shuffle type not supported: '-1'; expected one of [0 (NOSHUFFLE), 1 (BYTESHUFFLE), 2 (BITSHUFFLE)]",
+                    expected.getMessage());
+        }
+    }
 
-  @Test
-  public void createBloscValidBlockSizes() {
-      int[] blockSizes = { 0, 1, 20 };
-      for (int i = 0; i < blockSizes.length; i += 1) {
-          final Compressor compressor = CompressorFactory.create("blosc", "blocksize", blockSizes[i]);
-          assertNotNull(compressor);
-          assertEquals("blosc", compressor.getId());
-          assertEquals(
-              "compressor=blosc/cname=lz4" +
-              "/clevel=5/blocksize=" + blockSizes[i] +
-              "/shuffle=1", compressor.toString());
-      }
-  }
+    @Test
+    public void createBloscValidBlockSizes() {
+        int[] blockSizes = {0, 1, 20};
+        for (int i = 0; i < blockSizes.length; i += 1) {
+            final Compressor compressor = CompressorFactory.create("blosc", "blocksize", blockSizes[i]);
+            assertNotNull(compressor);
+            assertEquals("blosc", compressor.getId());
+            assertEquals(
+                    "compressor=blosc/cname=lz4" +
+                            "/clevel=5/blocksize=" + blockSizes[i] +
+                            "/shuffle=1", compressor.toString());
+        }
+    }
+
+    @Test
+    public void registerNewCompressor() {
+        final String id = "test";
+        CompressorFactory.registerCompressor(id, TestUtils.TestCompressor.class);
+        Compressor compressor = CompressorFactory.create(id, TestUtils.createMap("level", 1));
+        assertNotNull(compressor);
+        assertEquals(id, compressor.getId());
+        assertEquals(TestUtils.TestCompressor.class, compressor.getClass());CompressorFactory.registerCompressor(id, TestUtils.TestCompressor.class);
+
+        // Replacement
+        CompressorFactory.registerCompressor(id, CompressorFactory.BloscCompressor.class);
+        compressor = CompressorFactory.create(id);
+        assertNotNull(compressor);
+        // Expected not to match.
+        assertEquals("blosc", compressor.getId());
+        assertEquals(CompressorFactory.BloscCompressor.class, compressor.getClass());
+
+    }
 }

--- a/src/test/java/com/bc/zarr/TestUtils.java
+++ b/src/test/java/com/bc/zarr/TestUtils.java
@@ -98,4 +98,23 @@ public class TestUtils {
         }
         return deleted;
     }
+
+    public static class TestCompressor extends Compressor {
+        public TestCompressor(Map<String, Object> properties) {
+        }
+
+        public String getId() {
+            return "test";
+        }
+
+        public String toString() {
+            return getId();
+        }
+
+        public void compress(InputStream is, OutputStream os) throws IOException {
+        }
+
+        public void uncompress(InputStream is, OutputStream os) throws IOException {
+        }
+    }
 }


### PR DESCRIPTION
This is based on [PR #10 ](https://github.com/zarr-developers/jzarr/pull/10) with a small modification to allow a compressor implementation to be replaced, in addition to adding additional compressor ids.  There are situations where it makes sense to swap out a built-in compressor implementation, such as blosc.

Minor related changes:
* Adds methods to `CompressorFactory` to return the supported compressor ids and the implementations associated with each id.
* Cleanup of a blosc test that would generate output to System.err under non-error conditions.